### PR TITLE
Simplify new dev setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,5 +128,3 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Secrets file
-config.py

--- a/README.md
+++ b/README.md
@@ -1,12 +1,48 @@
 # wemakemoneybot
 
-This bot aids running the Reddit sub [r/WeMakeMoney](https://www.reddit.com/r/WeMakeMoney/).  
-The sub came about from a group of tight people from OG WSB and the post-GME different splinter subs.  
+This bot aids running the Reddit sub [r/WeMakeMoney](https://www.reddit.com/r/WeMakeMoney/).
+The sub came about from a group of tight people from OG WSB and the post-GME different splinter subs.
 
-## Usage
+## Setup
 
-Install and follow the output provided by install.sh.  
-The `config.py` looks as such:  
+Install requirements by doing `pip install --user -r requirements.txt`.
+Using a virtual environment is recommended!
+
+Create a new reddit account to act as your developer bot.
+You can get the praw client and secret ID by creating a new app (go to preferences > apps > create new app).
+Choose a web app and set redirect URI to http://localhost:8080.
+
+Create a `.env` file in the repo containing the following variables for your developer bot account.
+The initial `.env` file looks as such:
+```
+bot_username=<bot account username>
+bot_password=<bot account password>
+praw_client_id=<client id>
+praw_client_secret=<client secret key>
+```
+
+Then, run `python praw/obtain_refresh_token.py`.
+When prompted for scopes, enter the desired permissions or enter * for all permissions.
+Do not leave this prompt blank, or reddit will throw a very uninformative error once you follow the link.
+Follow the link that the script returns and accept the OAUTH2 scopes if you still agree with them.
+Your browser will redirect you to a page on `localhost:8080`, copy the refresh token.
+Add the refresh token to your `.env` file as `praw_refresh_token=<refresh token>`.
+
+Finally, add the target subreddit for the bot to the `.env` with `subreddit=<target subreddit>`.
+The bot will monitor comments posted to this subreddit to look for bot commands from subreddit users.
+
+It is useful to setup a private subreddit for development purposes only, so this target subreddit may change for development vs. production.
+
+## To run as a script
+
+Activate virtual environment if one is being used.
+Create a `config.py` as described below in "To run as a service section".
+Run the bot with `python wemakemoneybot.py`.
+
+## To run as a service
+
+Install and follow the output provided by install.sh.
+The `config.py` looks as such:
 ```python
 username = 'username'
 passwd = 'password123'

--- a/config.py
+++ b/config.py
@@ -1,0 +1,10 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+username=os.getenv('bot_username')
+passwd=os.getenv('bot_password')
+client_id=os.getenv('praw_client_id')
+client_secret=os.getenv('praw_client_secret')
+refresh_token=os.getenv('praw_refresh_token')

--- a/praw/obtain_refresh_token.py
+++ b/praw/obtain_refresh_token.py
@@ -29,9 +29,13 @@ import asyncio
 import random
 import socket
 import sys
+import os
 
 import asyncpraw
 
+from dotenv import load_dotenv
+
+load_dotenv()
 
 async def main():
     """Provide the program's entry point when directly executed."""
@@ -43,6 +47,10 @@ async def main():
     reddit = asyncpraw.Reddit(
         redirect_uri="http://localhost:8080",
         user_agent="obtain_refresh_token/v0 by u/bboe",
+        client_id=os.getenv('praw_client_id'),
+        client_secret=os.getenv('praw_client_secret'),
+        username=os.getenv('bot_username'),
+        password=os.getenv('bot_password')
     )
     state = str(random.randint(0, 65000))
     url = reddit.auth.url(scopes, state, "permanent")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
-pytesseract
-pillow
 asyncpraw
-yfinance
-requests
-selenium
+mplfinance
 nltk
 opencv-python
+pip-chill
+praw
+pytesseract
+python-dotenv
+selenium
+tabulate
+yfinance

--- a/wemakemoneybot.py
+++ b/wemakemoneybot.py
@@ -21,9 +21,14 @@ from nltk.sentiment import SentimentIntensityAnalyzer
 import nltk
 import re
 import concurrent.futures
+import os
+from dotenv import load_dotenv
 
 import rsi
 import config
+
+load_dotenv()
+target_subreddit = os.getenv('subreddit')
 
 tickerRE = re.compile(r"(?:\s)?([A-Z]{2,5})(?![a-z’'\.]+)(?:\s)?")
 
@@ -70,7 +75,7 @@ async def stockPrice(comment, *args):
                         await comment.reply(f'Latest price of {str(arg).upper()}: {data["regularMarketPrice"]}, {round(float(data["regularMarketChangePercent"]), 3)}%')
                 else:
                     try:
-                        await comment.reply(f'{str(arg).upper()} last traded: {data["regularMarketPrice"]}, {round(float(data["regularMarketChangePercent"]), 3)}%')    
+                        await comment.reply(f'{str(arg).upper()} last traded: {data["regularMarketPrice"]}, {round(float(data["regularMarketChangePercent"]), 3)}%')
                     except KeyError:
                         await comment.reply(f'Error occurred while getting price of {str(arg).upper()}\n```{traceback.format_exc()}```\n<@510951917128646657> fix your shitty code.')
             except IndexError:
@@ -131,13 +136,13 @@ commands = {
 
 
 async def run():
-    sub = await reddit.subreddit('WeMakeMoney')
+    sub = await reddit.subreddit(target_subreddit)
     async for comment in sub.stream.comments(skip_existing=True):
         c = str(comment.body)
         if '$' in c[0]:
             c = c.replace('\n', ' ')
             print(f'{datetime.now()} - Command: {c[1:].split(" ")[0]} - Params: {c[1:].split(" ")[1:]} - Comment: {comment}')
-            if c[1:].split(' ')[0] in commands.keys():                
+            if c[1:].split(' ')[0] in commands.keys():
                 try:
                     await commands[c[1:].split(' ')[0]](comment, c[1:].split(' ')[1:])
                 except:
@@ -184,7 +189,7 @@ async def checkTimer(submission):
     await asyncio.sleep(300)
     retest = await reddit.submission(submission)
     if retest.selftext == '[removed]':
-        print(f'{datetime.now()} - Stop timer for {submission.title} - Discarded.')         
+        print(f'{datetime.now()} - Stop timer for {submission.title} - Discarded.')
     else:
         print(f'{datetime.now()} - Stop timer for {submission.title} - Posting.')
         chain = 'N/A'
@@ -218,7 +223,7 @@ async def checkTimer(submission):
             try:
                 chain = stock.options[0:3]
                 response = f'\n```Snippet of Options Chain for {str(likely_ticker).upper()}\n'
-                
+
                 for item in chain:
                     response += f'EXP: {item}\n{stock.option_chain(item)[0].loc[:, ~stock.option_chain(item)[0].columns.isin(["contractSymbol", "lastTradeDate", "contractSize", "currency", "change", "percentChange"])].loc[stock.option_chain(item)[0]["inTheMoney"] == False].head(3)}\n'
                     chain_track += f'{stock.option_chain(item)[0].loc[:, ~stock.option_chain(item)[0].columns.isin(["contractSymbol", "lastTradeDate", "contractSize", "currency", "change", "percentChange"])].loc[stock.option_chain(item)[0]["inTheMoney"] == False].head(3)}\n'
@@ -259,15 +264,15 @@ async def checkTimer(submission):
         except (KeyError, IndexError):
             avgTot = "N/A"
             avg10 = "N/A"
-        
+
 
         try:
             if likely_ticker != '':
                 #if stock.info["volume"] > stock.info["averageVolume10days"] and avg10 > avgTot:
                 sub = await reddit.submission(submission)
-                _ = await sub.crosspost(subreddit='WeMakeMoney', send_replies=False)
+                _ = await sub.crosspost(subreddit=target_subreddit, send_replies=False)
             else:
-                return None           
+                return None
         except AttributeError:
             pass
 
@@ -282,7 +287,7 @@ async def streamer():
     sub = await reddit.subreddit('wallstreetbets')
     async for submission in sub.stream.submissions(skip_existing=True):
         try:
-            if submission.link_flair_text == 'DD':                                
+            if submission.link_flair_text == 'DD':
                 print(f'{datetime.now()} - Start timer for {submission.title}')
                 asyncio.create_task(checkTimer(submission))
 
@@ -292,7 +297,7 @@ async def streamer():
 
 if __name__ == '__main__':
     while True:
-        try:            
+        try:
             loop = asyncio.get_event_loop()
             loop.run_until_complete(main())
         except (prawcore.exceptions.ServerError, prawcore.exceptions.ResponseException):


### PR DESCRIPTION
This PR isn't merge ready! If you like the concept of these changes, I will modify the `install.sh` to copy the appropriate files so that the bot systemd service will work right. 

Made some changes/updates to the README that I think will help new devs spin up faster, if more were to join. Also added instructions for running the bot as a script, since I will likely never need to run it as a service. I will just run it as a script pointed at my private sub while I'm developing.

Biggest change in this PR is introduction of a .env file for use with the `python-dotenv` package. I basically moved the contents of `config.py` into `.env`, so now they can be seen from any subdirectory of the project. This enabled updating the `praw/obtain_refresh_token.py` script to just work on the first run once the `.env` file is setup. This also added the ability to switch the target subreddit the bot is deployed to through the .env file. I have a private subreddit I setup just for testing new bot features that I point it to.

`config.py` now can just read the `.env` file, but I think it could really be removed altogether if you like these changes and want to merge them. The pattern that would replace it would be calling `load_dotenv()` in any script inside the repo and then loading the appropriate env variables with `os.getenv`. Right now, this is what I am doing inside the `config.py` in this PR, but it seems like it may be an unnecessary extra layer of abstraction.
